### PR TITLE
Solve FutureWarning comparison to None

### DIFF
--- a/quickff/tools.py
+++ b/quickff/tools.py
@@ -300,7 +300,7 @@ def get_multiplicity(n1, n2):
     elif set([n1,n2])==set([3,3]): return 2
     elif set([n1,n2])==set([2,3]): return 2
     elif set([n1,n2])==set([2,2]): return 1
-    else:                          return None
+    else:                          return np.nan
 
 
 def get_restvalue(values, m, thresshold=20*deg, mode=1):

--- a/quickff/valence.py
+++ b/quickff/valence.py
@@ -390,12 +390,10 @@ class ValenceFF(ForcePartValence):
                     n1 = len(self.system.neighs1[dihed[1]])
                     n2 = len(self.system.neighs1[dihed[2]])
                     ms[i] = get_multiplicity(n1, n2)
-                nan = False
-                for m in ms:
-                    if np.isnan(m): nan = True
-                if nan or None in ms or ms.std()>1e-3:
+                if np.isnan(ms).any() or ms.std()>1e-3:
                     ms_string = str(ms)
-                    if nan: ms_string = 'nan'
+                    if np.isnan(ms).any():
+                        ms_string = 'nan'
                     log.warning('missing dihedral for %s (m is %s)' %('.'.join(types), ms_string))
                     continue
                 m = int(np.round(ms.mean()))


### PR DESCRIPTION
I got a lot of these lines in my output:

    quickff/quickff/valence.py:396: FutureWarning: comparison to `None` will result in an elementwise object comparison in the future.

This patch takes care of the warning.